### PR TITLE
Use AdvancedAlchemy internal metadata as canonical

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,11 +1,11 @@
 import typing
 
 import sqlalchemy as sa
-from advanced_alchemy.base import BigIntAuditBase
+from advanced_alchemy.base import BigIntAuditBase, orm_registry
 from sqlalchemy import orm
 
 
-METADATA: typing.Final = sa.MetaData()
+METADATA: typing.Final = orm_registry.metadata
 orm.DeclarativeBase.metadata = METADATA
 
 


### PR DESCRIPTION
Currently, the Alembic target `app.models.METADATA` does not actually reflect the metadata these models are being added to within the advanced alchemy registry