### PR TITLE
fix: restore CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Restores a `CLAUDE.md` that imports `AGENTS.md`. Without it, Claude Code loads **no** project
instructions for this repo.

The rename to `AGENTS.md` was made on the belief that Claude Code discovers `AGENTS.md` natively.
It does not. The documentation is explicit:

> Claude Code reads `CLAUDE.md`, not `AGENTS.md`.

The test that appeared to show otherwise was invalid: it ran with file tools available, so the model
simply read `AGENTS.md` off disk rather than receiving it as loaded context. Re-run with file tools
denied, a directory containing only `AGENTS.md` reports the instructions are **not** in context,
while a real `CLAUDE.md` control reports them correctly.

## Changes

Adds a one-line `CLAUDE.md`:

```
@AGENTS.md
```

`AGENTS.md` remains the single home of the content — this is an import, not a copy, so the two
cannot drift. Claude Code expands it at session start.

## Why an import rather than a symlink

Both work — each was verified with file tools denied. The import is preferred because a symlink
requires Administrator privileges or Developer Mode on Windows; without them the checkout gets a
plain text file containing the target path, which loads as garbage. The import is also the form the
documentation recommends, and it leaves room to append Claude-specific instructions below it later.

Part of modern-python/.github#51.
